### PR TITLE
Darwin support and Hydra builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { stdenv, makeWrapper, crystal, inclusive, nixFlakes, nixos-rebuild, openssh
-, awscli, gitMinimal, coreutils, systemd, gnugrep, terraform-with-plugins
+, awscli, gitMinimal, coreutils, gnugrep, terraform-with-plugins
 , consul, sops, libssh2, pkgconfig, cfssl, rsync, openssl, vault-bin }: {
   bitte = let
     inner = crystal.buildCrystalPackage {
@@ -29,7 +29,6 @@
       nixos-rebuild
       openssh
       sops
-      systemd
       terraform-with-plugins
       cfssl
       rsync

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,24 @@
 {
   "nodes": {
+    "crystal": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1602755823,
+        "narHash": "sha256-6MYxvT5e1xT4Kb1TKzk4AO3EefQTJ+juj38KUHV+NPI=",
+        "owner": "kreisys",
+        "repo": "crystal",
+        "rev": "6718e4f851347ce34d8fbabf516c6a0da85966f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kreisys",
+        "repo": "crystal",
+        "type": "github"
+      }
+    },
     "inclusive": {
       "inputs": {
         "stdlib": "stdlib"
@@ -20,6 +39,20 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1602739928,
+        "narHash": "sha256-mpfoeHf9QaMPNurSYeSkxerDfs6Fj7HDElSMXDaTOPQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2a4607f44222a92b8a44e6e1dac715e7eca04239",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1595425804,
         "narHash": "sha256-RM8fHq1PoN8HHVRPKIjYLrXq54Z18iVodQrwxmH/J3g=",
         "owner": "NixOS",
@@ -34,28 +67,12 @@
         "type": "github"
       }
     },
-    "nixpkgs-crystal": {
-      "locked": {
-        "lastModified": 1591785879,
-        "narHash": "sha256-RfTjvYLCdXw3dyOwbeDU4pDK9ex+QxrRQtMxqesWQOE=",
-        "owner": "manveru",
-        "repo": "nixpkgs",
-        "rev": "62267e49f4e13ed34d1ed328b3b5ff54be5efd18",
-        "type": "github"
-      },
-      "original": {
-        "owner": "manveru",
-        "ref": "crystal-0.35",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
+        "crystal": "crystal",
         "inclusive": "inclusive",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-crystal": "nixpkgs-crystal",
-        "utils": "utils"
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils_2"
       }
     },
     "stdlib": {
@@ -74,6 +91,21 @@
       }
     },
     "utils": {
+      "locked": {
+        "lastModified": 1601282935,
+        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
       "locked": {
         "lastModified": 1590791977,
         "narHash": "sha256-l26u9vRsdV9jkoBGlzFxTKLKtrZ38xCMZIG9h9ibFjQ=",

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   };
 
   outputs = { self, nixpkgs, crystal, inclusive, utils, ... }:
-    utils.lib.eachDefaultSystem (system: rec {
+    utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system: rec {
       overlay = final: prev: {
         nixos-rebuild = let
           nixos = nixpkgs.lib.nixosSystem {

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,13 @@
   description = "Flake to build bitte";
 
   inputs = {
-    nixpkgs-crystal.url = "github:manveru/nixpkgs/crystal-0.35";
+    crystal.url = "github:kreisys/crystal";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     inclusive.url = "github:manveru/nix-inclusive";
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-crystal, inclusive, utils, ... }:
+  outputs = { self, nixpkgs, crystal, inclusive, utils, ... }:
     utils.lib.eachDefaultSystem (system: rec {
       overlay = final: prev: {
         nixos-rebuild = let
@@ -23,7 +23,7 @@
 
         inherit (inclusive.lib) inclusive;
 
-        inherit (nixpkgs-crystal.legacyPackages.${system})
+        inherit (crystal.legacyPackages.${system})
           crystal shards crystal2nix;
 
         inherit (prev.callPackage ./. { inherit (final) nixos-rebuild; }) bitte;

--- a/flake.nix
+++ b/flake.nix
@@ -55,5 +55,7 @@
             pkgconfig
           ];
         };
+
+        hydraJobs = packages;
     });
 }


### PR DESCRIPTION
Changes include:

* flake build only for `x86_64-linux` and `x86_64-darwin` instead of all default platforms
  otherwise hydra complains due to lack of arm builders and such. (Theoretically might be more "correct" to add a required aggregate job instead?)
* use `packages` as `hydraJobs` in order to warm the cache
* use crystal from flake instead of nixpkgs
  as it's easier/faster to iterate that way. the flake is (mostly) copy-paste from @manveru's nixpkgs fork.
* remove systemd dependency
  as there's no `systemd` in darwin plus the dependency wasn't being used.