### PR TITLE
lib: improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,6 @@ dependencies = [
 name = "bitte-lib"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assert_cmd",
  "base64 0.13.0",
  "clap",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,7 +19,6 @@ tokio = "1.2.0"
 execute = "0.2.8"
 log = "0.4.14"
 pretty_env_logger = "0.4.0"
-anyhow = "1.0.38"
 thiserror = "1.0"
 base64 = "0.13.0"
 flate2 = { version = "1.0.17", features = ["zlib"], default-features = false }

--- a/lib/src/certs.rs
+++ b/lib/src/certs.rs
@@ -1,7 +1,7 @@
 use std::{fs, process::Command};
-use anyhow::Result;
 
 use serde::Deserialize;
+use crate::Result;
 
 use super::check_cmd;
 

--- a/lib/src/consul.rs
+++ b/lib/src/consul.rs
@@ -1,10 +1,10 @@
 use crate::types::ConsulAclTokenRead;
+use crate::Result;
 
 use super::sh;
-use anyhow::{Context, Result};
 
 // TODO: check that we have developer or admin policies
-pub fn consul_token() -> Result<String, anyhow::Error> {
+pub fn consul_token() -> Result<String> {
     match sh(execute::command_args!(
         "consul", "acl", "token", "read", "-self", "-format", "json"
     )) {
@@ -16,7 +16,7 @@ pub fn consul_token() -> Result<String, anyhow::Error> {
     }
 }
 
-fn issue_consul_token() -> Result<String, anyhow::Error> {
+fn issue_consul_token() -> Result<String> {
     sh(execute::command_args!(
         "vault",
         "read",
@@ -24,7 +24,6 @@ fn issue_consul_token() -> Result<String, anyhow::Error> {
         "token",
         "consul/creds/developer"
     ))
-    .context("unable to fetch Consul token from Vault")
 }
 
 /*

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -1,26 +1,49 @@
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum BitteError {
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
     #[error("timeout elapsed")]
     Timeout(#[from] tokio::time::error::Elapsed),
     #[error("exhausted {0} attempts")]
     ExhaustedAttempts(usize),
     #[error("connection with {0} failed")]
     ConnectionFailed(#[from] std::io::Error),
+    #[error("environment variable")]
+    EnvVar(#[from] std::env::VarError),
+    #[error("github token missin in ~/.netrc file")]
+    NoGithubToken,
+    #[error("error parsing json")]
+    SerdeError(#[from] serde_json::Error),
+    #[error("error making rest api request")]
+    RestsonError(#[from] restson::Error),
+    #[error("couldn't generate terraform config")]
+    FailedTerraformConfig,
+    #[error("error decoding base64 state")]
+    DecodeError(#[from] base64::DecodeError),
+    #[error("error parsing netrc file")]
+    NetrcError(netrc_rs::Error),
+    #[error("error executing external process")]
+    ExeError {
+        details: String,
+    },
     #[error("unknown error")]
     Unknown,
 }
 
+// NOTE netrc_rs doesn't impl StdError so can't simply `#[from]`
+impl From<netrc_rs::Error> for Error {
+    fn from(error: netrc_rs::Error) -> Self {
+        Error::NetrcError(error)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::BitteError;
+    use super::Error;
 
     #[tokio::test]
     // This silly test is to make sure we can match
     // specific errors!
     async fn test_unknown() {
-        let result: Result<(), BitteError> = Err(BitteError::Unknown);
+        let result: Result<(), Error> = Err(Error::Unknown);
         assert!(result.is_err());
     }
 }

--- a/lib/src/nomad.rs
+++ b/lib/src/nomad.rs
@@ -1,7 +1,7 @@
 use super::sh;
-use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use crate::Result;
 
 // TODO: check that we have developer or admin policies
 /*
@@ -18,7 +18,7 @@ Create Index = 2492001
 Modify Index = 2492001
 */
 
-pub fn nomad_token() -> Result<String, anyhow::Error> {
+pub fn nomad_token() -> Result<String> {
     match sh(execute::command_args!("nomad", "acl", "token", "self")) {
         Ok(output) => {
             for line in output.lines() {
@@ -36,7 +36,7 @@ pub fn nomad_token() -> Result<String, anyhow::Error> {
     }
 }
 
-fn issue_nomad_token() -> Result<String, anyhow::Error> {
+fn issue_nomad_token() -> Result<String> {
     sh(execute::command_args!(
         "vault",
         "read",
@@ -44,17 +44,16 @@ fn issue_nomad_token() -> Result<String, anyhow::Error> {
         "secret_id",
         "nomad/creds/developer"
     ))
-    .context("unable to fetch Nomad token from Vault")
 }
 
 impl std::fmt::Display for Topic {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_fmt(format_args!("{:?}", self))
     }
 }
 
 impl std::fmt::Display for NomadEvent {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(events) = &self.events {
             for event in events {
                 formatter.write_fmt(format_args!("Topic: {}\n", event.topic))?;
@@ -69,7 +68,7 @@ impl std::fmt::Display for NomadEvent {
 }
 
 impl std::fmt::Display for Payload {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(allocation) = &self.allocation {
             formatter.write_fmt(format_args!("\n    JobID: {}\n", allocation.job_id))?;
         };

--- a/lib/src/rebuild.rs
+++ b/lib/src/rebuild.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::Result;
 use log::info;
 use std::{env, path::Path, process::Command, time::Duration};
 
@@ -36,8 +36,7 @@ fn copy_to(instance: &Instance, _attempts: u64, copy: bool) -> Result<()> {
             "{}#nixosConfigurations.{}.config.secrets.generateScript",
             flake, instance.uid
         )
-    ))
-    .context("secrets.generateScript failed, you might need to upgrade bitte")?;
+    ))?;
 
     let target = format!("{}#{}", flake, instance.flake_attr);
     let cache = format!(

--- a/lib/src/ssh.rs
+++ b/lib/src/ssh.rs
@@ -3,15 +3,15 @@ use tokio::{net::TcpStream, time};
 use std::time::Duration;
 
 use super::check_cmd;
-use super::error::BitteError as Error;
+use crate::{Result, error::Error};
 
-pub fn ssh_keygen(ip: &str) -> Result<(), Error> {
+pub fn ssh_keygen(ip: &str) -> Result<()> {
     check_cmd(Command::new("ssh-keygen").arg("-R").arg(ip))
         .map_err(|_| Error::Unknown)?;
     Ok(())
 }
 
-pub fn wait_for_ready(cluster: &str, ip: &str) -> Result<(), Error> {
+pub fn wait_for_ready(cluster: &str, ip: &str) -> Result<()> {
     let target = format!("root@{}", ip);
 
     let mut ssh_args = vec![
@@ -40,14 +40,13 @@ pub fn wait_for_ready(cluster: &str, ip: &str) -> Result<(), Error> {
     Ok(())
 }
 
-pub async fn wait_for_ssh(ip: &str) -> Result<(), Error> {
+pub async fn wait_for_ssh(ip: &str) -> Result<()> {
     let res = wait_for_port(&ip, 22, 10000, 120).await?;
     Ok(res)
 }
 
 pub async fn wait_for_port(ip: &str, port: usize, duration_in_ms: u64, attempts: usize) ->
-                                                                                        Result<(),
-    Error> {
+                                                                                        Result<()> {
     let addr = format!("{}:{}", ip, port);
     let timeout_duration = Duration::from_millis(duration_in_ms);
     let mut interval = time::interval(timeout_duration);


### PR DESCRIPTION
This removes the `anyhow` crate from lib and replace it with custom errors
created using the `thiserror` crate.
This is needed in order to facilitate matching specific errors in consumer apps (namely `bitte` and `iogo`)