### PR TITLE
Add passthrough subcommand to bitte terraform

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,6 +28,10 @@ async fn main() -> Result<()> {
         (@subcommand plan => (about: "terraform plan")
           (@arg destroy: --destroy -d "create a destruction plan"))
         (@subcommand apply => (about: "terraform apply"))
+        (@subcommand passthrough =>
+          (about: "delegate to terraform")
+          (aliases: &["passthru", "pt"])
+          (@arg args: +takes_value +multiple "arguments to terraform"))
         (@subcommand init => (about: "terraform init")
           (@arg upgrade: --upgrade -u "upgrade provider versions"))
         (@subcommand output => (about: "terraform output")))


### PR DESCRIPTION
Aliased as `passthru` and `pt` because life is too short.

This simply sets up the environment as it would before plan/apply and
then runs terraform with whatever arguments passed.
Useful when we need a yet-to-be-implemented terraform command and we
don't want to bug manveru for the right environment variables or dive
into rusty rabbitholes 😌