### PR TITLE
Adds asgSuffix output column to bitte info

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -231,10 +231,13 @@ async fn info_print(output: TerraformStateValue) -> Result<()> {
         "Status",
         "Protected",
         "PrivateIp",
-        "PublicIp"
+        "PublicIp",
+        "asgSuffix"
     ]);
 
     for (_key, val) in output.asgs.iter() {
+        let asgPrefix = format!("client-{}-{}", val.region, val.instance_type.replace(".", "-"));
+        let asgSuffix = _key.strip_prefix(&asgPrefix).unwrap_or_else(|| "ERROR").replace("-", "");
         let info = info::asg_info(val.arn.as_str(), val.region.as_str()).await;
         for asgi in info {
             // TODO: rewrite to take all required instance ids as argument to save time
@@ -250,6 +253,7 @@ async fn info_print(output: TerraformStateValue) -> Result<()> {
                 asgi.protected_from_scale_in,
                 iii.private_ip_address.unwrap_or_default(),
                 iii.public_ip_address.unwrap_or_default(),
+                asgSuffix,
             ]);
             // asg_table.add_row(row![key, val.instance_type, val.flake_attr, val.count,]);
         }


### PR DESCRIPTION
Displays an asgSuffix on a client node, if present:

```
+---------------------+------------+---------------+-----------+---------+-----------+---------------+----------------+-----------+
| Id                  | Type       | AZ            | State     | Status  | Protected | PrivateIp     | PublicIp       | asgSuffix |
+---------------------+------------+---------------+-----------+---------+-----------+---------------+----------------+-----------+
| i-00000000000000001 | t3a.xlarge | us-east-2b    | InService | Healthy | false     | 10.1.2.3.4    | 3.1.2.3        |           |
+---------------------+------------+---------------+-----------+---------+-----------+---------------+----------------+-----------+
| i-00000000000000002 | t3a.xlarge | us-east-2c    | InService | Healthy | false     | 10.1.2.3.5    | 3.1.2.4        | unstable  |
+---------------------+------------+---------------+-----------+---------+-----------+---------------+----------------+-----------+
```