### PR TITLE
Various updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1623182707,
-        "narHash": "sha256-JmnqZVS1VP/tSQGSeNs+ru3F3it3ceev7k2rcL4rBGw=",
+        "lastModified": 1624553342,
+        "narHash": "sha256-lHVDPxuvLk0eMGijxnFADfEz1VIyJUwGpaa6ywjyzPQ=",
         "owner": "kreisys",
         "repo": "flake-utils",
-        "rev": "f5b5f258e88d0de1ec97d2e892f20b38796f48ea",
+        "rev": "911d24db17074f5e9e4f183e461558397ca38ab7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,56 +1,67 @@
 {
   "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1623927034,
+        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "e09c320446c5c2516d430803f7b19f5833781337",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1613226215,
-        "narHash": "sha256-3rA5cGIrBHD6yeKhNhsF7/t461ww25oJY8KyBb0IhjU=",
+        "lastModified": 1624553300,
+        "narHash": "sha256-I7T+UqFG7e9cdqcIh0mlQ+HLNU4xxbQXc6jB0FPafnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff96a0fa5635770390b184ae74debea75c3fd534",
+        "rev": "8004e04140b1c8a2cb34768e99c1209b349fc708",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1624492865,
+        "narHash": "sha256-y0sgj+z1qdfdtd5gmYbdSK3zx1SsJnyM8gZqZVH2g5c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "65db0350fe3962c41b8604046ec9166976f80793",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "rust": "rust",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
         "utils": "utils"
-      }
-    },
-    "rust": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1617363019,
-        "narHash": "sha256-w9VUHPPndNPGPSumta4cEhhRQBUL1jMxiZmZtwYY8JU=",
-        "owner": "input-output-hk",
-        "repo": "rust.nix",
-        "rev": "2fd5fce3ec67e6915cb79cbf132f023e147b31ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "work",
-        "repo": "rust.nix",
-        "type": "github"
       }
     },
     "utils": {
       "locked": {
-        "lastModified": 1613500319,
-        "narHash": "sha256-ybAq6pImFCSnwyhhmnnvV567JM4GuhCEG/PHBkSS86U=",
+        "lastModified": 1623182707,
+        "narHash": "sha256-JmnqZVS1VP/tSQGSeNs+ru3F3it3ceev7k2rcL4rBGw=",
         "owner": "kreisys",
         "repo": "flake-utils",
-        "rev": "28e72370213c9bc2cf094ab07b8ac95f3c6bb60f",
+        "rev": "f5b5f258e88d0de1ec97d2e892f20b38796f48ea",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,14 +19,14 @@
         bitte = final.callPackage ./package.nix {};
       };
 
-      packages = { bitte, ... }: {
+      packages = { bitte }: {
         defaultPackage = bitte;
         inherit bitte;
       };
 
-      hydraJobs = { bitte, ... }@ps: ps;
+      hydraJobs = { bitte }@ps: ps;
 
-      devShell = { mkShell, pkgs, ... }:
+      devShell = { mkShell, pkgs }:
         mkShell {
           RUST_BACKTRACE = "1";
           RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;

--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,6 @@
       preOverlays = [ naersk ];
 
       overlay = final: prev: {
-        nixos-rebuild = prev.nixos-rebuild.overrideAttrs (o: {
-          src = prev.runCommand "nixos-rebuild.sh" { inherit (o) src; } ''
-            substitute $src $out \
-            --replace systemctl false
-          '';
-        });
-
         bitte = with builtins;
           prev.naersk.buildPackage {
             # Without this we end up with a drv called `rust-workspace-unknown`
@@ -45,12 +38,12 @@
           };
       };
 
-      packages = { bitte, nixos-rebuild, ... }: {
+      packages = { bitte, ... }: {
         defaultPackage = bitte;
-        inherit bitte nixos-rebuild;
+        inherit bitte;
       };
 
-      hydraJobs = { bitte, nixos-rebuild, ... }@ps: ps;
+      hydraJobs = { bitte, ... }@ps: ps;
 
       devShell = { mkShell, pkgs, ... }:
         mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -16,26 +16,7 @@
       preOverlays = [ naersk ];
 
       overlay = final: prev: {
-        bitte = with builtins;
-          final.naersk.buildPackage {
-            # Without this we end up with a drv called `rust-workspace-unknown`
-            # which makes `nix run` try to execute a bin with that name.
-            inherit ((fromTOML (readFile ./cli/Cargo.toml)).package)
-              name version;
-            root = self;
-            buildInputs = with final; [ pkg-config openssl zlib ];
-
-            overrideMain = _: {
-              postInstall = ''
-                mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
-
-                echo "generate completion scripts for iogo"
-                $out/bin/iogo completions bash > "$out/share/bash-completion/completions/iogo"
-                $out/bin/iogo completions fish > "$out/share/fish/vendor_completions.d/iogo.fish"
-                $out/bin/iogo completions zsh >  "$out/share/zsh/site-functions/_iogo"
-              '';
-            };
-          };
+        bitte = final.callPackage ./package.nix {};
       };
 
       packages = { bitte, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -3,18 +3,17 @@
 
   inputs = {
     utils.url = "github:kreisys/flake-utils";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    rust.url = "github:input-output-hk/rust.nix/work";
-    rust.inputs.nixpkgs.follows = "nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    naersk.url = "github:nmattia/naersk";
   };
 
-  outputs = { self, nixpkgs, rust, utils, ... }:
+  outputs = { self, nixpkgs, naersk, utils, ... }:
     utils.lib.simpleFlake {
       inherit nixpkgs;
 
       systems = [ "x86_64-darwin" "x86_64-linux" ];
 
-      preOverlays = [ rust ];
+      preOverlays = [ naersk ];
 
       overlay = final: prev: {
         nixos-rebuild = prev.nixos-rebuild.overrideAttrs (o: {
@@ -25,7 +24,7 @@
         });
 
         bitte = with builtins;
-          prev.rust-nix.buildPackage {
+          prev.naersk.buildPackage {
             # Without this we end up with a drv called `rust-workspace-unknown`
             # which makes `nix run` try to execute a bin with that name.
             inherit ((fromTOML (readFile ./cli/Cargo.toml)).package)

--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,13 @@
 
       overlay = final: prev: {
         bitte = with builtins;
-          prev.naersk.buildPackage {
+          final.naersk.buildPackage {
             # Without this we end up with a drv called `rust-workspace-unknown`
             # which makes `nix run` try to execute a bin with that name.
             inherit ((fromTOML (readFile ./cli/Cargo.toml)).package)
               name version;
             root = self;
-            buildInputs = with prev; [ pkg-config openssl zlib ];
+            buildInputs = with final; [ pkg-config openssl zlib ];
 
             overrideMain = _: {
               postInstall = ''

--- a/package.nix
+++ b/package.nix
@@ -9,7 +9,8 @@ naersk.buildPackage {
   inherit (with builtins; (fromTOML (readFile ./cli/Cargo.toml)).package)
   name version;
   root = ./.;
-  buildInputs = [ pkg-config openssl zlib ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl zlib ];
 
   overrideMain = _: {
     postInstall = ''

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,24 @@
+{ naersk
+, pkg-config
+, openssl
+, zlib }:
+
+naersk.buildPackage {
+  # Without this we end up with a drv called `rust-workspace-unknown`
+  # which makes `nix run` try to execute a bin with that name.
+  inherit (with builtins; (fromTOML (readFile ./cli/Cargo.toml)).package)
+  name version;
+  root = ./.;
+  buildInputs = [ pkg-config openssl zlib ];
+
+  overrideMain = _: {
+    postInstall = ''
+      mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
+
+      echo "generate completion scripts for iogo"
+      $out/bin/iogo completions bash > "$out/share/bash-completion/completions/iogo"
+      $out/bin/iogo completions fish > "$out/share/fish/vendor_completions.d/iogo.fish"
+      $out/bin/iogo completions zsh >  "$out/share/zsh/site-functions/_iogo"
+    '';
+  };
+}


### PR DESCRIPTION
- Switch to naersk, bump nixpkgs, flake-utils
- Remove patched `nixos-rebuild` from overlay as it is already included and patched upstream
- Use `final` instead of `prev` where appropriate (using `prev` exposed a bug in `simpleFlake` whereby overlays were not applied in the "correct" order, this has been fixed and I verified that It now works with `prev` as well, but `final` is correcter in this particular context)
- Factor package out of flake
- Remove redundant ellipses




