### PR TITLE
fix exit status on subcommand failure

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -137,9 +137,7 @@ pub async fn terraform_plan(workspace: String, sub: &ArgMatches) -> Result<()> {
         full = full.arg("-destroy");
     }
 
-    info!("run: {:?}", full);
-    full.status()
-        .with_context(|| format!("failed to run: {:?}", full))?;
+    bitte_lib::check_cmd(full)?;
     Ok(())
 }
 
@@ -173,9 +171,7 @@ pub async fn terraform_passthrough(workspace: String, sub: &ArgMatches) -> Resul
     let mut cmd = Command::new("terraform");
     let full = cmd.args(args);
 
-    info!("run: {:?}", full);
-    full.status()
-        .with_context(|| format!("failed to run: {:?}", full))?;
+    bitte_lib::check_cmd(full)?;
     Ok(())
 }
 
@@ -201,9 +197,7 @@ pub async fn terraform_apply(workspace: String, _sub: &ArgMatches) -> Result<()>
     let mut cmd = Command::new("terraform");
     let full = cmd.arg("apply").arg(plan_file);
 
-    debug!("run: {:?}", full);
-    full.status()
-        .with_context(|| format!("failed to run: {:?}", full))?;
+    bitte_lib::check_cmd(full)?;
     Ok(())
 }
 
@@ -266,8 +260,14 @@ async fn info_print(output: TerraformStateValue) -> Result<()> {
                 asgi.lifecycle_state,
                 asgi.health_status,
                 asgi.protected_from_scale_in,
-                instance.private_ip_address.as_ref().unwrap_or(&"".to_string()),
-                instance.public_ip_address.as_ref().unwrap_or(&"".to_string()),
+                instance
+                    .private_ip_address
+                    .as_ref()
+                    .unwrap_or(&"".to_string()),
+                instance
+                    .public_ip_address
+                    .as_ref()
+                    .unwrap_or(&"".to_string()),
                 asg_suffix,
             ]);
             // asg_table.add_row(row![key, val.instance_type, val.flake_attr, val.count,]);

--- a/iogo/src/cli.rs
+++ b/iogo/src/cli.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     env,
     io::Write,
-    process::{exit, Command, ExitStatus},
+    process::{exit, Command},
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -386,14 +386,15 @@ fn lookup_current_vault_token() -> Result<String> {
 }
 
 // TODO: give option to login using aws?
-fn vault_login() -> Result<ExitStatus> {
-    Command::new("vault")
-        .args(vec![
-            "login",
-            "-method=github",
-            "-path=github-employees",
-            "-no-print",
-        ])
-        .status()
-        .context("vault login failed")
+fn vault_login() -> Result<()> {
+    let mut cmd = Command::new("vault");
+    let full = cmd.args(vec![
+        "login",
+        "-method=github",
+        "-path=github-employees",
+        "-no-print",
+    ]);
+
+    bitte_lib::check_cmd(full)?;
+    Ok(())
 }


### PR DESCRIPTION
@kreisys pointed out that bitte rebuild exits 0 even if a rebuid fails. This should resolve the situation why more explicitly checking the exit code and returning an Err if it's non-zero. Additionally, I use souped up library function more pervasively in the codebase.