### PR TITLE
implement an asynchronous, data driven architecture

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
 # watch_file flake.nix
 # watch_file flake.lock
-# mkdir -p "$(direnv_layout_dir)"
-# eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile")"
-
-use nix
+if ! has nix_direnv_version || ! nix_direnv_version 1.4.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.4.0/direnvrc" "sha256-4XfVDjv75eHMWN4G725VW7BoOV4Vl3vAabK4YXIfPyE="
+fi
+use flake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +123,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "backtrace"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +202,7 @@ dependencies = [
  "base64 0.13.0",
  "clap",
  "colored",
+ "enum-utils",
  "execute",
  "flate2",
  "log",
@@ -582,6 +607,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed327f716d0d351d86c9fd3398d20ee39ad8f681873cc081da2ca1c10fed398a"
+dependencies = [
+ "enum-utils-from-str",
+ "failure",
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "enum-utils-from-str"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49be08bad6e4ca87b2b8e74146987d4e5cb3b7512efa50ef505b51a22227ee1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +679,15 @@ name = "execute-command-tokens"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31582eb1260be08aa265f004aca0a74e1b69ce432d8e53ebd85c5c145617ece"
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "filetime"
@@ -871,6 +929,12 @@ dependencies = [
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "glob"
@@ -1515,6 +1579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,6 +2279,17 @@ name = "serde_derive"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "deploy-rs"
 version = "0.1.0"
-source = "git+https://github.com/nrdxp/deploy-rs?branch=as-lib#cfa203b1d344bb68b995a15a8adeb4f23da09ab5"
+source = "git+https://github.com/serokell/deploy-rs#d72174307d5b88ec24cc2e69e875228fe3d642ed"
 dependencies = [
  "clap",
  "flexi_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "arrayref"
@@ -70,6 +70,19 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "tempfile",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite 0.2.6",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -160,6 +173,7 @@ dependencies = [
 name = "bitte-lib"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "base64 0.13.0",
  "clap",
@@ -173,6 +187,7 @@ dependencies = [
  "pretty_env_logger",
  "prettytable-rs",
  "regex",
+ "reqwest",
  "restson",
  "rusoto_autoscaling",
  "rusoto_core",
@@ -183,6 +198,7 @@ dependencies = [
  "shellexpand",
  "thiserror",
  "tokio 1.9.0",
+ "uuid",
 ]
 
 [[package]]
@@ -557,6 +573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,9 +917,28 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 0.2.25",
- "tokio-util",
+ "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.9.0",
+ "tokio-util 0.6.7",
+ "tracing",
 ]
 
 [[package]]
@@ -1006,7 +1050,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
  "http-body 0.3.1",
  "httparse",
@@ -1030,6 +1074,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.3.3",
  "http",
  "http-body 0.4.2",
  "httparse",
@@ -1170,10 +1215,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -1265,6 +1325,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
@@ -1839,6 +1905,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+dependencies = [
+ "async-compression",
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.2",
+ "hyper 0.14.9",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.2.6",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.0",
+ "tokio 1.9.0",
+ "tokio-native-tls",
+ "tokio-util 0.6.7",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "restson"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,7 +2004,7 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "rusoto_core",
- "serde_urlencoded",
+ "serde_urlencoded 0.6.1",
  "xml-rs",
 ]
 
@@ -1958,7 +2061,7 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "rusoto_core",
- "serde_urlencoded",
+ "serde_urlencoded 0.6.1",
  "xml-rs",
 ]
 
@@ -2124,6 +2227,18 @@ dependencies = [
  "itoa",
  "serde",
  "url",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2568,6 +2683,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.6",
+ "tokio 1.9.0",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2884,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2762,6 +2902,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2792,6 +2944,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "whoami"
@@ -2841,6 +3003,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ws2_32-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitte"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "bitte-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [ "cli", "lib", "iogo" ]
 
 [profile.release]
-lto = true
+lto = "fat"
+codegen-units = 1

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.14"
 pretty_env_logger = "0.4.0"
 anyhow = "1.0"
 duct = "0.13"
-deploy-rs = { git = "https://github.com/nrdxp/deploy-rs", branch = "as-lib" }
+deploy-rs = { git = "https://github.com/serokell/deploy-rs" }
 
 [dependencies.clap]
 version = "3.0.0-beta.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bitte"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["manveru <michael.fellinger@iohk.io>"]
+description = "Deploy all the things!"
 edition = "2018"
 
 [dependencies]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -142,13 +142,15 @@ pub(crate) async fn ssh(sub: &ArgMatches, cluster: ClusterHandle) -> Result<()> 
 pub(crate) async fn rebuild(sub: &ArgMatches, cluster: ClusterHandle) -> Result<()> {
     let only: Vec<String> = sub.values_of_t("only").unwrap_or_default();
     let delay = Duration::from_secs(sub.value_of_t::<u64>("delay").unwrap_or(0));
-    let copy: bool = sub.value_of_t("copy").unwrap_or(false);
+    let copy: bool = sub.is_present("copy");
+    let clients: bool = sub.is_present("clients");
 
     rebuild::set_ssh_opts(true)?;
     rebuild::copy(
         only.iter().map(|o| o.as_str()).collect(),
         delay,
         copy,
+        clients,
         cluster,
     )
     .await?;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -302,7 +302,17 @@ async fn info_print(cluster: ClusterHandle, json: bool) -> Result<()> {
     if json {
         let stdout = io::stdout();
         let handle = stdout.lock();
-        serde_json::to_writer_pretty(handle, &cluster.await??)?;
+        let mut cluster = cluster.await??;
+        let nodes = cluster
+            .nodes
+            .into_iter()
+            .map(|mut node| {
+                node.nomad_client = None;
+                node
+            })
+            .collect();
+        cluster.nodes = nodes;
+        serde_json::to_writer_pretty(handle, &cluster)?;
     } else {
         let mut instance_table = Table::new();
         instance_table.add_row(row!["Name", "Private IP", "Public IP"]);

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -94,7 +94,7 @@ pub(crate) async fn ssh(sub: &ArgMatches, cluster: ClusterHandle) -> Result<()> 
                         alloc.namespace == namespace
                             && &alloc.job_id == name
                             && &alloc.task_group == group
-                            && Some(alloc.index) == index.parse().ok()
+                            && alloc.index.get() == index.parse().ok()
                     })
                     .is_some()
             })

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -4,7 +4,7 @@ use clap::ArgMatches;
 use deploy::cli;
 use log::*;
 use prettytable::{cell, row, Table};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::{env, io, path::Path, process::Command, time::Duration};
 
 pub(crate) async fn certs(sub: &ArgMatches) -> Result<()> {
@@ -312,7 +312,14 @@ async fn info_print(cluster: ClusterHandle, json: bool) -> Result<()> {
             if name.is_empty() {
                 name = node.nixos.unwrap_or_default();
             }
-            instance_table.add_row(row![name, node.priv_ip.unwrap(), node.pub_ip.unwrap()]);
+
+            let no_ip = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+
+            instance_table.add_row(row![
+                name,
+                node.priv_ip.unwrap_or(no_ip),
+                node.pub_ip.unwrap_or(no_ip)
+            ]);
         }
 
         instance_table.printstd();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -91,6 +91,7 @@ pub(crate) async fn ssh(sub: &ArgMatches, cluster: ClusterHandle) -> Result<()> 
                         && &alloc.job_id == name
                         && &alloc.task_group == group
                         && alloc.index.get() == index.parse().ok()
+                        && alloc.status == "running"
                 })
             })
             .with_context(|| {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -86,17 +86,12 @@ pub(crate) async fn ssh(sub: &ArgMatches, cluster: ClusterHandle) -> Result<()> 
                     return false;
                 };
 
-                allocs
-                    .as_ref()
-                    .unwrap()
-                    .into_iter()
-                    .find(|alloc| {
-                        alloc.namespace == namespace
-                            && &alloc.job_id == name
-                            && &alloc.task_group == group
-                            && alloc.index.get() == index.parse().ok()
-                    })
-                    .is_some()
+                allocs.as_ref().unwrap().iter().any(|alloc| {
+                    alloc.namespace == namespace
+                        && &alloc.job_id == name
+                        && &alloc.task_group == group
+                        && alloc.index.get() == index.parse().ok()
+                })
             })
             .with_context(|| {
                 format!(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -302,7 +302,7 @@ async fn info_print(cluster: ClusterHandle, json: bool) -> Result<()> {
     if json {
         let stdout = io::stdout();
         let handle = stdout.lock();
-        serde_json::to_writer(handle, &cluster.await??)?;
+        serde_json::to_writer_pretty(handle, &cluster.await??)?;
     } else {
         let mut instance_table = Table::new();
         instance_table.add_row(row!["Name", "Private IP", "Public IP"]);

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -297,16 +297,7 @@ async fn info_print(cluster: ClusterHandle, json: bool) -> Result<()> {
     if json {
         let stdout = io::stdout();
         let handle = stdout.lock();
-        let mut cluster = cluster.await??;
-        let nodes = cluster
-            .nodes
-            .into_iter()
-            .map(|mut node| {
-                node.nomad_client = None;
-                node
-            })
-            .collect();
-        cluster.nodes = nodes;
+        let cluster = cluster.await??;
         serde_json::to_writer_pretty(handle, &cluster)?;
     } else {
         let mut instance_table = Table::new();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -299,6 +299,7 @@ async fn info_print(cluster: ClusterHandle, json: bool) -> Result<()> {
         let stdout = io::stdout();
         let handle = stdout.lock();
         let cluster = cluster.await??;
+        env::set_var("BITTE_INFO_NO_ALLOCS", "");
         serde_json::to_writer_pretty(handle, &cluster)?;
     } else {
         let mut instance_table = Table::new();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -292,14 +292,11 @@ async fn info_print(cluster: ClusterHandle, json: bool) -> Result<()> {
         let nodes = cluster.await??.nodes;
 
         for node in nodes.into_iter() {
-            let mut name = if node.nomad_client.is_some() {
+            let name = if node.nomad_client.is_some() {
                 node.nomad_client.unwrap().id.to_hyphenated().to_string()
             } else {
                 node.name
             };
-            if name.is_empty() {
-                name = node.nixos;
-            }
 
             instance_table.add_row(row![name, node.priv_ip, node.pub_ip]);
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,8 @@ use deploy::cli::Opts;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let _cluster = tokio::spawn(bitte_lib::find_bitte_cluster());
+
     let mut app = clap_app!(bitte =>
       (version: "0.0.1")
       (author: "Michael Fellinger <michael.fellinger@iohk.io>")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,9 @@ use deploy::cli::Opts;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let _cluster = tokio::spawn(bitte_lib::find_bitte_cluster());
+    let cluster = tokio::spawn(bitte_lib::find_bitte_cluster()).await??;
+    let file = std::fs::File::create(format!("{}.json", cluster.name))?;
+    serde_json::to_writer(file, &cluster)?;
 
     let mut app = clap_app!(bitte =>
       (version: "0.0.1")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,13 +1,14 @@
 mod cli;
 
 use anyhow::{bail, Result};
+use bitte_lib::types::BitteCluster;
 use clap::clap_app;
 use clap::IntoApp;
 use deploy::cli::Opts;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cluster = tokio::spawn(bitte_lib::find_bitte_cluster()).await??;
+    let cluster = tokio::spawn(BitteCluster::new()).await??;
     let file = std::fs::File::create(format!("{}.json", cluster.name))?;
     serde_json::to_writer(file, &cluster)?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,9 +8,7 @@ use deploy::cli::Opts;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cluster = tokio::spawn(BitteCluster::new()).await??;
-    let file = std::fs::File::create(format!("{}.json", cluster.name))?;
-    serde_json::to_writer(file, &cluster)?;
+    let cluster = tokio::spawn(BitteCluster::new());
 
     let mut app = clap_app!(bitte =>
       (version: "0.0.1")
@@ -22,7 +20,8 @@ async fn main() -> Result<()> {
         (@arg delay: --delay +takes_value "seconds to delay between rebuilds")
         (@arg copy: --copy "copy to the S3 cache first"))
       (@subcommand info =>
-        (about: "Show information about instances and auto-scaling groups"))
+        (about: "Show information about instances and auto-scaling groups")
+        (@arg json: --json "format as json"))
       (@subcommand ssh =>
         (about: "SSH to instances")
         (@arg host: +takes_value "host")
@@ -70,7 +69,7 @@ async fn main() -> Result<()> {
         Some(("deploy", sub)) => cli::deploy(sub).await,
         Some(("info", sub)) => {
             pretty_env_logger::init();
-            cli::info(sub).await
+            cli::info(sub, cluster).await
         }
         Some(("ssh", sub)) => {
             pretty_env_logger::init();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,13 +1,20 @@
 mod cli;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use bitte_lib::types::{BitteCluster, ClusterHandle};
 use clap::clap_app;
 use clap::IntoApp;
 use deploy::cli::Opts;
+use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    env::var("IN_NIX_SHELL")
+        .and(env::var("BITTE_DOMAIN"))
+        .context(concat!(
+            "This program should be run from a bitte shell:\n",
+            "https://github.com/input-output-hk/bitte/blob/master/pkgs/bitte-shell.nix"
+        ))?;
     let cluster: ClusterHandle = BitteCluster::init();
 
     let mut app = clap_app!(bitte =>

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,14 +1,14 @@
 mod cli;
 
 use anyhow::{bail, Result};
-use bitte_lib::types::BitteCluster;
+use bitte_lib::types::{BitteCluster, ClusterHandle};
 use clap::clap_app;
 use clap::IntoApp;
 use deploy::cli::Opts;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cluster = tokio::spawn(BitteCluster::new());
+    let cluster: ClusterHandle = BitteCluster::init();
 
     let mut app = clap_app!(bitte =>
       (version: "0.0.1")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
             "This program should be run from a bitte shell:\n",
             "https://github.com/input-output-hk/bitte/blob/master/pkgs/bitte-shell.nix"
         ))?;
+
     let cluster: ClusterHandle = BitteCluster::init();
 
     let mut app = clap_app!(bitte =>

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
       (@subcommand ssh =>
         (about: "SSH to instances")
         (@arg job: -j --job +takes_value +multiple #{3, 3} "specify client by: job group alloc_index")
+        (@arg all: -a --all conflicts_with[job] "run [args] on all nodes")
         (@arg namespace: -n --namespace +takes_value "specify nomad namespace to search for <job>; only valid for --job flag")
         (@arg args: +takes_value +multiple "arguments to ssh"))
       (@subcommand terraform =>

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,8 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let _toml = include_str!("../Cargo.toml");
+
     env::var("IN_NIX_SHELL")
         .and(env::var("BITTE_DOMAIN"))
         .context(concat!(
@@ -18,10 +20,10 @@ async fn main() -> Result<()> {
 
     let cluster: ClusterHandle = BitteCluster::init();
 
-    let mut app = clap_app!(bitte =>
-      (version: "0.0.1")
-      (author: "Michael Fellinger <michael.fellinger@iohk.io>")
-      (about: "Deploy all the things!")
+    let mut app = clap_app!((clap::crate_name!()) =>
+      (version: clap::crate_version!())
+      (author: clap::crate_authors!("\n"))
+      (about: clap::crate_description!())
       (@subcommand rebuild =>
         (about: "nixos-rebuild")
         (@arg only: -o --only +takes_value +multiple "pattern of hosts to deploy")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,12 +16,13 @@ async fn main() -> Result<()> {
       (about: "Deploy all the things!")
       (@subcommand rebuild =>
         (about: "nixos-rebuild")
-        (@arg only: --only +takes_value +multiple "pattern of hosts to deploy")
-        (@arg delay: --delay +takes_value "seconds to delay between rebuilds")
-        (@arg copy: --copy "copy to the S3 cache first"))
+        (@arg only: -o --only +takes_value +multiple "pattern of hosts to deploy")
+        (@arg clients: -l --clients conflicts_with[only] "rebuild all nomad client nodes")
+        (@arg delay: -d --delay +takes_value "seconds to delay between rebuilds")
+        (@arg copy: -c --copy "copy to the S3 cache first"))
       (@subcommand info =>
         (about: "Show information about instances and auto-scaling groups")
-        (@arg json: --json "format as json"))
+        (@arg json: -j --json "format as json"))
       (@subcommand ssh =>
         (about: "SSH to instances")
         (@arg job: -j --job +takes_value +multiple #{3, 3} "specify client by: job group alloc_index")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
     match matches.subcommand() {
         Some(("rebuild", sub)) => {
             pretty_env_logger::init();
-            cli::rebuild(sub).await
+            cli::rebuild(sub, cluster).await
         }
         Some(("deploy", sub)) => cli::deploy(sub).await,
         Some(("info", sub)) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,7 +24,8 @@ async fn main() -> Result<()> {
         (@arg json: --json "format as json"))
       (@subcommand ssh =>
         (about: "SSH to instances")
-        (@arg host: +takes_value "host")
+        (@arg job: -j --job +takes_value +multiple #{3, 3} "specify client by: job group alloc_index")
+        (@arg namespace: -n --namespace +takes_value "specify nomad namespace to search for <job>; only valid for --job flag")
         (@arg args: +takes_value +multiple "arguments to ssh"))
       (@subcommand terraform =>
         (about: "Run terraform")
@@ -73,7 +74,7 @@ async fn main() -> Result<()> {
         }
         Some(("ssh", sub)) => {
             pretty_env_logger::init();
-            cli::ssh(sub).await
+            cli::ssh(sub, cluster).await
         }
         Some(("terraform", sub)) => {
             pretty_env_logger::init();
@@ -87,10 +88,13 @@ async fn main() -> Result<()> {
             pretty_env_logger::init();
             cli::certs(sub).await
         }
-        _ => bail!(format!(
-            "Invalid subcommand\n {}",
-            String::from_utf8(help_text).expect("help text contains invalid UTF8")
-        )),
+        _ => {
+            cluster.abort();
+            bail!(format!(
+                "Invalid subcommand\n {}",
+                String::from_utf8(help_text).expect("help text contains invalid UTF8")
+            ))
+        }
     }?;
     Ok(())
 }

--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,0 @@
-(import ./flake-compat.nix).defaultNix.default

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,6 +1,0 @@
-# The `default.nix` in flake-compat reads `flake.nix` and `flake.lock` from `src` and
-# returns an attribute set of the shape `{ defaultNix, shellNix }`
-
-import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
-  src = ./.;
-}

--- a/flake.lock
+++ b/flake.lock
@@ -5,15 +5,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1623927034,
-        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
-        "owner": "nmattia",
+        "lastModified": 1623558292,
+        "narHash": "sha256-YjyRflpvKzstN9Yy5pVOmreckcL1Fu6TGe8Tf8y9fm4=",
+        "owner": "yusdacra",
         "repo": "naersk",
-        "rev": "e09c320446c5c2516d430803f7b19f5833781337",
+        "rev": "f411315a2954bd60bdcba2bc0cff7f4b0012a12a",
         "type": "github"
       },
       "original": {
-        "owner": "nmattia",
+        "owner": "yusdacra",
+        "ref": "feat/cargolock-git-deps",
         "repo": "naersk",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     utils.url = "github:kreisys/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    naersk.url = "github:nmattia/naersk";
+    naersk.url = "github:yusdacra/naersk?ref=feat/cargolock-git-deps";
   };
 
   outputs = { self, nixpkgs, naersk, utils, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,7 @@
 
       preOverlays = [ naersk ];
 
-      overlay = final: prev: {
-        bitte = final.callPackage ./package.nix {};
-      };
+      overlay = final: prev: { bitte = final.callPackage ./package.nix { }; };
 
       packages = { bitte }: {
         defaultPackage = bitte;
@@ -31,26 +29,28 @@
           RUST_BACKTRACE = "1";
           RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
 
-          buildInputs = with pkgs; [
-            cfssl
-            sops
-            openssl
-            zlib
-            pkg-config
-            rust-analyzer
-            cargo
-            clippy
-            rls
-            rustc
-            rustfmt
-          ] ++ lib.optionals stdenv.isDarwin (with darwin; with apple_sdk.frameworks; [
-            libiconv
-            libresolv
-            Libsystem
-            SystemConfiguration
-            Security
-            CoreFoundation
-          ]);
+          buildInputs = with pkgs;
+            [
+              cfssl
+              sops
+              openssl
+              zlib
+              pkg-config
+              rust-analyzer
+              cargo
+              clippy
+              rls
+              rustc
+              rustfmt
+            ] ++ lib.optionals stdenv.isDarwin (with darwin;
+              with apple_sdk.frameworks; [
+                libiconv
+                libresolv
+                Libsystem
+                SystemConfiguration
+                Security
+                CoreFoundation
+              ]);
         };
-      };
-    }
+    };
+}

--- a/iogo/src/cli.rs
+++ b/iogo/src/cli.rs
@@ -147,7 +147,7 @@ struct CueExport {
     rendered: HashMap<String, HashMap<String, serde_json::Value>>,
 }
 
-async fn plan_jobs(namespace: &String) -> Result<()> {
+async fn plan_jobs(namespace: &str) -> Result<()> {
     let output = sh(execute::command_args!("cue", "export"))?;
     let export: CueExport =
         serde_json::from_str(output.as_str()).context("Couldn't parse CUE export")?;
@@ -212,7 +212,7 @@ fn execute_plan(client: &mut RestClient, render: &mut CueRender, plan: NomadJobP
 
     match render.job.periodic {
         // TODO: Implement alternate deployment check logic for periodic jobs
-        Some(_) => return Ok(()),
+        Some(_) => Ok(()),
         None => loop {
             println!("The EvalID is: {:?}", run.eval_id);
             let evaluation: NomadEvaluation = client.get(run.eval_id.as_str())?;
@@ -396,15 +396,9 @@ fn lookup_current_vault_token(ignore_env: bool) -> Result<String> {
 // TODO: give option to login using aws?
 fn vault_login(print: bool) -> Result<ExitStatus> {
     let mut cmd = Command::new("vault");
-    cmd.args(vec![
-        "login",
-        "-method=github",
-        "-path=github-employees",
-    ]);
+    cmd.args(vec!["login", "-method=github", "-path=github-employees"]);
     if !print {
         cmd.arg("-no-print");
     }
-    cmd
-        .status()
-        .context("vault login failed")
+    cmd.status().context("vault login failed")
 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -27,6 +27,7 @@ colored = "2"
 uuid = { version = "0.8", features = ["serde"] }
 reqwest = { version = "0.11.4", features = ["json", "gzip"] }
 anyhow = "1.0.42"
+enum-utils = "0.1.2"
 
 [dependencies.clap]
 version = "3.0.0-beta.2"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 regex = "*"
 restson = "0.7.0"
 serde_json = "1.0"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = "1.0", features = [ "derive", "rc" ] }
 shellexpand = "2.1"
 prettytable-rs = "^0.8.0"
 rusoto_ec2 = "^0.46"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,6 +24,9 @@ base64 = "0.13.0"
 flate2 = { version = "1.0.17", features = ["zlib"], default-features = false }
 netrc-rs = "0.1.2"
 colored = "2"
+uuid = { version = "0.8", features = ["serde"] }
+reqwest = { version = "0.11.4", features = ["json", "gzip"] }
+anyhow = "1.0.42"
 
 [dependencies.clap]
 version = "3.0.0-beta.2"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitte-lib"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["manveru <michael.fellinger@iohk.io>"]
 edition = "2018"
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     NetrcMissing,
     #[error("error executing external process: {details}")]
     ExeError { details: String },
+    #[error("current BITTE_PROVIDER is not valid: {provider}")]
+    ProviderError { provider: String },
     #[error("unknown error")]
     Unknown,
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -17,8 +17,6 @@ use std::env;
 use std::process::Command;
 use std::process::Stdio;
 
-use self::types::{BitteCluster, BitteProvider};
-
 use info::{asg_info, instance_info};
 
 #[cfg(test)]
@@ -43,12 +41,6 @@ mod test_bitte_cluster {
 pub fn bitte_cluster() -> Result<String> {
     let cluster = env::var("BITTE_CLUSTER")?;
     Ok(cluster)
-}
-
-pub async fn find_bitte_cluster() -> anyhow::Result<BitteCluster> {
-    let domain = env::var("BITTE_DOMAIN")?;
-    let name = bitte_cluster()?;
-    BitteCluster::new(name, domain, BitteProvider::AWS).await
 }
 
 fn handle_command_error_common(

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -17,6 +17,8 @@ use std::env;
 use std::process::Command;
 use std::process::Stdio;
 
+use self::types::{BitteCluster, BitteProvider};
+
 use info::{asg_info, instance_info};
 
 #[cfg(test)]
@@ -41,6 +43,12 @@ mod test_bitte_cluster {
 pub fn bitte_cluster() -> Result<String> {
     let cluster = env::var("BITTE_CLUSTER")?;
     Ok(cluster)
+}
+
+pub async fn find_bitte_cluster() -> anyhow::Result<BitteCluster> {
+    let domain = env::var("BITTE_DOMAIN")?;
+    let name = bitte_cluster()?;
+    BitteCluster::new(name, domain, BitteProvider::AWS).await
 }
 
 fn handle_command_error_common(

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -17,8 +17,6 @@ use std::env;
 use std::process::Command;
 use std::process::Stdio;
 
-use info::{asg_info, instance_info};
-
 #[cfg(test)]
 mod test_bitte_cluster {
     use super::*;
@@ -114,86 +112,4 @@ impl Instance {
             s3_cache,
         }
     }
-}
-
-pub async fn find_instance(needle: &str) -> Option<Instance> {
-    terraform::set_http_auth().expect("Couldn't authenticate with infra Vault");
-    match find_instances(vec![needle]).await.first() {
-        Some(instance) => Some(instance.clone()),
-        None => None,
-    }
-}
-
-async fn find_instances(patterns: Vec<&str>) -> Vec<Instance> {
-    let output = terraform::output("clients")
-        .or_else(|_| terraform::output("core"))
-        .expect("Couldn't fetch clients or core workspaces");
-
-    let mut results = Vec::new();
-
-    let only_clients = patterns.contains(&"clients");
-
-    if !only_clients {
-        for instance in output.instances.values().into_iter() {
-            let matched = patterns.is_empty()
-                || patterns.iter().any(|pattern| {
-                    [
-                        instance.private_ip.as_str(),
-                        instance.public_ip.as_str(),
-                        instance.name.as_str(),
-                    ]
-                    .contains(pattern)
-                });
-
-            if matched {
-                results.push(Instance::new(
-                    instance.public_ip.to_string(),
-                    instance.name.to_string(),
-                    instance.uid.to_string(),
-                    instance.flake_attr.to_string(),
-                    output.s3_cache.to_string(),
-                ));
-            }
-        }
-    }
-
-    for (_, asg) in output.asgs {
-        let asg_infos = asg_info(asg.arn.as_str(), asg.region.as_str()).await;
-        for asg_info in asg_infos {
-            let instance_infos =
-                instance_info(vec![asg_info.instance_id.as_str()], asg.region.as_str()).await;
-            for instance_info in instance_infos {
-                let matched = patterns.is_empty()
-                    || { patterns.len() == 1 && only_clients }
-                    || patterns.iter().any(|pattern| {
-                        [
-                            instance_info.instance_id.as_ref(),
-                            instance_info.public_dns_name.as_ref(),
-                            instance_info.public_ip_address.as_ref(),
-                            instance_info.private_dns_name.as_ref(),
-                            instance_info.private_ip_address.as_ref(),
-                        ]
-                        .iter()
-                        .map(|x| x.map_or_else(|| "", |y| y.as_str()))
-                        .collect::<String>()
-                        .contains(pattern)
-                    });
-                if matched {
-                    if let Some(ip) = instance_info.public_ip_address {
-                        results.push(Instance::new(
-                            ip,
-                            instance_info
-                                .instance_id
-                                .map_or_else(|| "".to_string(), |x| x),
-                            asg.uid.clone(),
-                            asg.flake_attr.clone(),
-                            output.s3_cache.clone(),
-                        ))
-                    }
-                }
-            }
-        }
-    }
-
-    results
 }

--- a/lib/src/nomad.rs
+++ b/lib/src/nomad.rs
@@ -19,24 +19,6 @@ Modify Index = 2492001
 */
 
 pub fn nomad_token() -> Result<String> {
-    match sh(execute::command_args!("nomad", "acl", "token", "self")) {
-        Ok(output) => {
-            for line in output.lines() {
-                let parts: Vec<&str> = line.splitn(2, '=').collect();
-                let key = parts[0].trim();
-
-                if key == "Secret ID" {
-                    let value = parts[1].trim();
-                    return Ok(value.to_string());
-                }
-            }
-            issue_nomad_token()
-        }
-        Err(_err) => issue_nomad_token(),
-    }
-}
-
-fn issue_nomad_token() -> Result<String> {
     sh(execute::command_args!(
         "vault",
         "read",

--- a/lib/src/rebuild.rs
+++ b/lib/src/rebuild.rs
@@ -1,21 +1,33 @@
-use crate::Result;
+use anyhow::Result;
 use log::info;
-use std::{env, path::Path, process::Command, time::Duration};
+use std::{env, net::IpAddr, path::Path, process::Command, time::Duration};
 
 use super::{
-    bitte_cluster, check_cmd, find_instances, handle_command_error, ssh::wait_for_ssh, Instance,
+    bitte_cluster, check_cmd, handle_command_error,
+    ssh::wait_for_ssh,
+    types::{BitteFind, BitteNode, ClusterHandle},
 };
 
-pub async fn copy(only: Vec<&str>, delay: Duration, copy: bool) -> Result<()> {
+pub async fn copy(
+    only: Vec<&str>,
+    delay: Duration,
+    copy: bool,
+    cluster: ClusterHandle,
+) -> Result<()> {
     info!("only: {:?}", only);
-    let instances = find_instances(only.clone()).await.into_iter();
-    let instance_names: Vec<String> = instances.clone().map(|i| i.name).collect();
-    info!("instances: {:?}", instance_names);
-    let mut iter = instances.peekable();
+
+    let cluster = cluster.await??;
+    let instances = if only.is_empty() {
+        cluster.nodes
+    } else {
+        cluster.nodes.find_needles(only)
+    };
+
+    let mut iter = instances.iter().peekable();
 
     while let Some(instance) = iter.next() {
         info!("rebuild: {}", instance.name);
-        wait_for_ssh(&instance.public_ip).await?;
+        wait_for_ssh(&instance.pub_ip).await?;
         copy_to(&instance, 10, copy)?;
         if iter.peek().is_some() {
             tokio::time::sleep(delay).await;
@@ -25,8 +37,8 @@ pub async fn copy(only: Vec<&str>, delay: Duration, copy: bool) -> Result<()> {
     Ok(())
 }
 
-fn copy_to(instance: &Instance, _attempts: u64, copy: bool) -> Result<()> {
-    env::set_var("IP", instance.public_ip.clone());
+fn copy_to(instance: &BitteNode, _attempts: u64, _copy: bool) -> Result<()> {
+    env::set_var("IP", instance.pub_ip.to_string());
     let flake = ".";
 
     handle_command_error(execute::command_args!(
@@ -34,26 +46,29 @@ fn copy_to(instance: &Instance, _attempts: u64, copy: bool) -> Result<()> {
         "run",
         format!(
             "{}#nixosConfigurations.{}.config.secrets.generateScript",
-            flake, instance.uid
+            flake, instance.nixos
         )
     ))?;
 
-    let target = format!("{}#{}", flake, instance.flake_attr);
-    let cache = format!(
-        "{}&secret-key=secrets/nix-secret-key-file",
-        instance.s3_cache
+    let target = format!(
+        "{}#nixosConfigurations.{}.config.system.build.toplevel",
+        flake, instance.nixos
     );
-    let rebuild_flake: String = format!("{}#{}", flake, instance.uid);
+    // let cache = format!(
+    //     "{}&secret-key=secrets/nix-secret-key-file",
+    //     instance.s3_cache
+    // );
+    let rebuild_flake: String = format!("{}#{}", flake, instance.nixos);
 
     nix_build(&target)?;
-    if copy {
-        nix_copy_to_cache(&target, &cache)?;
-    }
-    nix_copy_to_machine(&target, &instance.public_ip)?;
-    nixos_rebuild(&rebuild_flake, &instance.public_ip)
+    // if copy {
+    //     nix_copy_to_cache(&target, &cache)?;
+    // }
+    nix_copy_to_machine(&target, &instance.pub_ip)?;
+    nixos_rebuild(&rebuild_flake, &instance.pub_ip)
 }
 
-pub fn nixos_rebuild(target: &str, ip: &str) -> Result<()> {
+pub fn nixos_rebuild(target: &str, ip: &IpAddr) -> Result<()> {
     check_cmd(
         Command::new("nixos-rebuild")
             .arg("switch")
@@ -84,7 +99,7 @@ pub fn nix_copy_to_cache(target: &str, cache: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn nix_copy_to_machine(target: &str, ssh: &str) -> Result<()> {
+pub fn nix_copy_to_machine(target: &str, ssh: &IpAddr) -> Result<()> {
     check_cmd(
         Command::new("nix")
             .arg("-L")

--- a/lib/src/ssh.rs
+++ b/lib/src/ssh.rs
@@ -1,3 +1,4 @@
+use std::net::IpAddr;
 use std::time::Duration;
 use std::{path::Path, process::Command};
 use tokio::{net::TcpStream, time};
@@ -5,12 +6,13 @@ use tokio::{net::TcpStream, time};
 use super::check_cmd;
 use crate::{error::Error, Result};
 
-pub fn ssh_keygen(ip: &str) -> Result<()> {
-    check_cmd(Command::new("ssh-keygen").arg("-R").arg(ip)).map_err(|_| Error::Unknown)?;
+pub fn ssh_keygen(ip: &IpAddr) -> Result<()> {
+    check_cmd(Command::new("ssh-keygen").arg("-R").arg(ip.to_string()))
+        .map_err(|_| Error::Unknown)?;
     Ok(())
 }
 
-pub fn wait_for_ready(cluster: &str, ip: &str) -> Result<()> {
+pub fn wait_for_ready(cluster: &str, ip: &IpAddr) -> Result<()> {
     let target = format!("root@{}", ip);
 
     let mut ssh_args = vec![
@@ -38,13 +40,13 @@ pub fn wait_for_ready(cluster: &str, ip: &str) -> Result<()> {
     Ok(())
 }
 
-pub async fn wait_for_ssh(ip: &str) -> Result<()> {
+pub async fn wait_for_ssh(ip: &IpAddr) -> Result<()> {
     let res = wait_for_port(&ip, 22, 10000, 120).await?;
     Ok(res)
 }
 
 pub async fn wait_for_port(
-    ip: &str,
+    ip: &IpAddr,
     port: usize,
     duration_in_ms: u64,
     attempts: usize,

--- a/lib/src/terraform.rs
+++ b/lib/src/terraform.rs
@@ -64,10 +64,7 @@ pub fn init(upgrade: bool) -> Result<()> {
     set_http_auth()?;
     println!("run: terraform init");
 
-    match remove_dir_all(".terraform") {
-        Ok(_) => {}
-        Err(_) => {}
-    }
+    remove_dir_all(".terraform").ok();
 
     if upgrade {
         Command::new("terraform")
@@ -111,7 +108,7 @@ pub fn output(workspace: &str) -> Result<TerraformStateValue> {
 fn github_token() -> Result<String> {
     let exp = &tilde("~/.netrc").to_string();
     let path = Path::new(exp);
-    let netrc_file = read_to_string(path).or_else(|_| Err(Error::NetrcMissing))?;
+    let netrc_file = read_to_string(path).map_err(|_| Error::NetrcMissing)?;
     let netrc = Netrc::parse(netrc_file, true)?;
     for machine in &netrc.machines {
         if let Some(name) = &machine.name {

--- a/lib/src/terraform.rs
+++ b/lib/src/terraform.rs
@@ -83,22 +83,6 @@ pub fn init(upgrade: bool) -> Result<()> {
     Ok(())
 }
 
-fn nix_current_system() -> String {
-    let result = Command::new("nix")
-        .args(&[
-            "eval",
-            "--impure",
-            "--raw",
-            "--expr",
-            "builtins.currentSystem",
-        ])
-        .output();
-    match result {
-        Ok(output) => String::from_utf8_lossy(&output.stdout).trim().to_string(),
-        Err(_) => "x86_64-linux".into(),
-    }
-}
-
 fn terraform_vault_client() -> Result<RestClient> {
     let mut client = RestClient::new("https://vault.infra.aws.iohkdev.io")?;
     let token = vault_token()?;

--- a/lib/src/terraform.rs
+++ b/lib/src/terraform.rs
@@ -39,12 +39,7 @@ pub fn generate_terraform_config(workspace: &str) -> Result<()> {
     let status = Command::new("nix")
         .arg("-L")
         .arg("run")
-        .arg(format!(
-            ".#clusters.{}.{}.tf.{}.config",
-            nix_current_system(),
-            cluster,
-            workspace
-        ))
+        .arg(format!(".#clusters.{}.tf.{}.config", cluster, workspace))
         .status()
         .and_then(|status| {
             if !status.success() {

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -721,6 +721,7 @@ impl BitteNode {
 type NomadClients = Vec<NomadClient>;
 type NomadAllocs = Vec<NomadAlloc>;
 type BitteNodes = Vec<BitteNode>;
+pub type ClusterHandle = JoinHandle<anyhow::Result<BitteCluster>>;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NomadAlloc {

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -571,7 +571,7 @@ pub struct BitteCluster {
     pub nomad_client: Arc<Client>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
 pub enum BitteProvider {
     AWS,
 }
@@ -647,9 +647,9 @@ impl BitteCluster {
         };
         let allocs = tokio::spawn(BitteCluster::find_allocs(
             Arc::clone(&nomad_client),
-            domain.clone(),
+            domain.to_owned(),
         ));
-        let nodes = tokio::spawn(BitteCluster::find_nodes(provider.clone()));
+        let nodes = tokio::spawn(BitteCluster::find_nodes(provider));
 
         let allocs = allocs.await??;
         let nodes = nodes.await?;

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -792,7 +792,7 @@ impl BitteNode {
                                 None => None,
                             };
 
-                            if node.name == "" {
+                            if node.name.is_empty() {
                                 for inst in state.instances.values() {
                                     if inst.private_ip == node.priv_ip.to_string() {
                                         node.name = inst.name.clone()

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use enum_utils;
+use enum_utils::FromStr;
 use std::net::{IpAddr, Ipv4Addr};
 use uuid::Uuid;
 
@@ -580,9 +580,10 @@ pub struct BitteCluster {
     pub ttl: SystemTime,
 }
 
-#[derive(Debug, Serialize, Deserialize, Copy, Clone, enum_utils::FromStr)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, FromStr)]
 pub enum BitteProvider {
-    AWS,
+ #[allow(clippy::upper_case_acronyms)]
+ AWS,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -53,7 +53,7 @@ impl RestPath<(&str, &str)> for RawVaultState {
 
 impl RestPath<&str> for CueRender {
     fn get_path(id: &str) -> Result<String, restson::Error> {
-        Ok(format!("/v1/job/{}/plan", id).to_string())
+        Ok(format!("/v1/job/{}/plan", id))
     }
 }
 
@@ -65,13 +65,13 @@ impl RestPath<()> for CueRender {
 
 impl RestPath<&str> for NomadEvaluation {
     fn get_path(eval_id: &str) -> Result<String, restson::Error> {
-        Ok(format!("/v1/evaluation/{}", eval_id).to_string())
+        Ok(format!("/v1/evaluation/{}", eval_id))
     }
 }
 
 impl RestPath<&str> for NomadDeployment {
     fn get_path(deployment_id: &str) -> Result<String, restson::Error> {
-        Ok(format!("/v1/deployment/{}", deployment_id).to_string())
+        Ok(format!("/v1/deployment/{}", deployment_id))
     }
 }
 
@@ -125,19 +125,15 @@ require progress by: {}",
                 }
                 NomadDeploymentStatus::Complete => {
                     println!("{}", description.green());
-                    return;
                 }
                 NomadDeploymentStatus::Successful => {
                     println!("{}", description.green());
-                    return;
                 }
                 NomadDeploymentStatus::Failed => {
                     println!("{}", description.red());
-                    return;
                 }
                 NomadDeploymentStatus::Cancelled => {
                     println!("{}", description.red());
-                    return;
                 }
             },
             None => {}
@@ -720,7 +716,7 @@ impl BitteNode {
                 let asg_regions = env::var("AWS_ASG_REGIONS")?;
                 let default_region = env::var("AWS_DEFAULT_REGION")?;
                 let regions_str = format!("{}:{}", asg_regions, default_region);
-                let regions: HashSet<&str> = regions_str.split(":").collect();
+                let regions: HashSet<&str> = regions_str.split(':').collect();
                 let mut handles = Vec::new();
 
                 for region in regions.iter() {
@@ -810,7 +806,7 @@ impl BitteNode {
                     result.append(&mut nodes);
                 }
 
-                return Ok((result, state.s3_cache));
+                Ok((result, state.s3_cache))
             }
         }
     }
@@ -879,14 +875,14 @@ where
     let buf = AllocIndex::deserialize(deserializer)?;
 
     match buf {
-        AllocIndex::Int(i) => return Ok(AllocIndex::Int(i)),
+        AllocIndex::Int(i) => Ok(AllocIndex::Int(i)),
         AllocIndex::String(s) => {
             let search = Regex::new("[0-9]*\\]$").unwrap().find(&s).unwrap().as_str();
 
             let index = &search[0..search.len() - 1];
             let index: u32 = index.parse().unwrap();
 
-            return Ok(AllocIndex::Int(index));
+            Ok(AllocIndex::Int(index))
         }
     }
 }
@@ -909,7 +905,7 @@ impl BitteCluster {
                 env::set_var("NOMAD_TOKEN", &token);
                 token
             });
-            let mut token = HeaderValue::from_str(&*&token)?;
+            let mut token = HeaderValue::from_str(&token)?;
             token.set_sensitive(true);
             let mut headers = HeaderMap::new();
             headers.insert("X-Nomad-Token", token);

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -582,8 +582,8 @@ pub struct BitteCluster {
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, FromStr)]
 pub enum BitteProvider {
- #[allow(clippy::upper_case_acronyms)]
- AWS,
+    #[allow(clippy::upper_case_acronyms)]
+    AWS,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -619,7 +619,7 @@ pub struct BitteNode {
 }
 
 fn skip_info(_: &Option<NomadClient>) -> bool {
-    env::args().any(|arg| arg == "info")
+    env::var("BITTE_INFO_NO_ALLOCS").is_ok()
 }
 
 pub trait BitteFind

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -787,7 +787,12 @@ impl BitteCluster {
         };
 
         let nomad_api_client = {
-            let mut token = HeaderValue::from_str(nomad::nomad_token()?.as_str())?;
+            let token = env::var("NOMAD_TOKEN").unwrap_or({
+                let token = nomad::nomad_token()?;
+                env::set_var("NOMAD_TOKEN", &token);
+                token
+            });
+            let mut token = HeaderValue::from_str(&*&token)?;
             token.set_sensitive(true);
             let mut headers = HeaderMap::new();
             headers.insert("X-Nomad-Token", token);

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -585,7 +585,7 @@ pub enum BitteProvider {
     AWS,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct NomadClient {
     #[serde(rename(deserialize = "ID"))]
     pub id: Uuid,

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -613,7 +613,12 @@ pub struct BitteNode {
     pub priv_ip: IpAddr,
     pub pub_ip: IpAddr,
     pub nixos: String,
+    #[serde(skip_serializing_if = "skip_info")]
     pub nomad_client: Option<NomadClient>,
+}
+
+fn skip_info(_: &Option<NomadClient>) -> bool {
+    env::args().any(|arg| arg == "info")
 }
 
 pub trait BitteFind

--- a/package.nix
+++ b/package.nix
@@ -1,13 +1,6 @@
-{ stdenv
-, lib
-, naersk
-, pkg-config
-, openssl
-, zlib
-
-  # darwin dependencies
-, darwin
-}:
+{ stdenv, lib, pkg-config, openssl, zlib, rustPlatform, naersk
+# darwin dependencies
+, darwin }:
 
 naersk.buildPackage {
   # Without this we end up with a drv called `rust-workspace-unknown`
@@ -16,24 +9,24 @@ naersk.buildPackage {
     name version;
   root = ./.;
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl zlib ]
-    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-    SystemConfiguration
-    Security
-    CoreFoundation
-    darwin.libiconv
-    darwin.libresolv
-    darwin.Libsystem
-  ]);
+  buildInputs = [ openssl zlib ] ++ lib.optionals stdenv.isDarwin
+    (with darwin.apple_sdk.frameworks; [
+      SystemConfiguration
+      Security
+      CoreFoundation
+      darwin.libiconv
+      darwin.libresolv
+      darwin.Libsystem
+    ]);
 
   overrideMain = _: {
     postInstall = ''
-            mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
+      mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
 
-            echo "generate completion scripts for iogo"
-            $out/bin/iogo completions bash > "$out/share/bash-completion/completions/iogo"
-            $out/bin/iogo completions fish > "$out/share/fish/vendor_completions.d/iogo.fish"
-            $out/bin/iogo completions zsh >  "$out/share/zsh/site-functions/_iogo"
+      echo "generate completion scripts for iogo"
+      $out/bin/iogo completions bash > "$out/share/bash-completion/completions/iogo"
+      $out/bin/iogo completions fish > "$out/share/fish/vendor_completions.d/iogo.fish"
+      $out/bin/iogo completions zsh >  "$out/share/zsh/site-functions/_iogo"
     '';
   };
 }

--- a/package.nix
+++ b/package.nix
@@ -5,7 +5,7 @@
 , openssl
 , zlib
 
-# darwin dependencies
+  # darwin dependencies
 , darwin
 }:
 
@@ -13,27 +13,27 @@ naersk.buildPackage {
   # Without this we end up with a drv called `rust-workspace-unknown`
   # which makes `nix run` try to execute a bin with that name.
   inherit (with builtins; (fromTOML (readFile ./cli/Cargo.toml)).package)
-  name version;
+    name version;
   root = ./.;
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl zlib ]
     ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-      SystemConfiguration
-      Security
-      CoreFoundation
-      darwin.libiconv
-      darwin.libresolv
-      darwin.Libsystem
-    ]);
+    SystemConfiguration
+    Security
+    CoreFoundation
+    darwin.libiconv
+    darwin.libresolv
+    darwin.Libsystem
+  ]);
 
   overrideMain = _: {
     postInstall = ''
-      mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
+            mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
 
-      echo "generate completion scripts for iogo"
-      $out/bin/iogo completions bash > "$out/share/bash-completion/completions/iogo"
-      $out/bin/iogo completions fish > "$out/share/fish/vendor_completions.d/iogo.fish"
-      $out/bin/iogo completions zsh >  "$out/share/zsh/site-functions/_iogo"
+            echo "generate completion scripts for iogo"
+            $out/bin/iogo completions bash > "$out/share/bash-completion/completions/iogo"
+            $out/bin/iogo completions fish > "$out/share/fish/vendor_completions.d/iogo.fish"
+            $out/bin/iogo completions zsh >  "$out/share/zsh/site-functions/_iogo"
     '';
   };
 }

--- a/release.nix
+++ b/release.nix
@@ -1,1 +1,0 @@
-(import ./flake-compat.nix).defaultNix.hydraJobs

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,0 @@
-(import ./flake-compat.nix).shellNix.default


### PR DESCRIPTION
## Impetus
This should drastically reduce the complexity of the implementation by describing all the relevant information we need into a single unified `BitteCluster` struct.

In addition, the current implementation relies on synchronous, blocking API calls, which is why many of the commands are painfully slow. By making proper use of the multi-threaded tokio runtime and the asynchronous reqwest library, we can drastically reduce this burden by making each call in parallel.

Also, the cli will now start building this cluster defining struct at the very beginning of the main function in a separate thread, in order to keep the waiting to a bare minimum.

As an example of why it is awesome and useful to have our own data format, checkout how I obtain the alloc index even though the Nomad API doesn't usually expose it directly:
https://github.com/input-output-hk/bitte-cli/blob/f0d0647bbf3d8df5f108c0c488e3da568481f065/lib/src/types.rs#L612-L627

## Tasks:
- [x] Initial defintion of a `BitteCluster` struct (subject to feedback)
- [x] Make all API calls asynchronously and in parallel
  - [x] Implement async function to pull the relevant Nomad allocation information.
  - [x] Implement async function to pull the relevant Nomad node information.
  - [x] Implement async function to pull the relevant bitte cluster node information, e.g. IP, etc.
- [x] Refactor the entire codebase to rely on this `BitteCluster` struct instead of making ad hoc API calls everywhere
- [x] Serialize the `BitteCluster` struct to a known location so Nix can import it and automatically define deploy-rs nodes. see #18
- [x] Implement a semantic versioning scheme once this PR is ready, so we can have a sane development process :smile:
- [x] fix darwin build

## Stretch goals:
- [x] Use the serialized definition as a cache to avoid unecesary API calls when running the cli in quick succession
- [x] Improve cli semantics by allow for things like `bitte ssh $job $task $index`
- [ ] Use the serialization to generate cluster aware cli completions

> ### Note:
> The `BitteProvider` enum only has a single value atm, but it's there to make things simpler when we move everything to on-premise, while still maintaining compatibility with AWS. This also leaves open the option to add other cloud platforms in the future by simply implementing the `find_bitte_nodes()` function for that provider.