### PR TITLE
rebuild: copy store derivations

### DIFF
--- a/lib/src/rebuild.rs
+++ b/lib/src/rebuild.rs
@@ -127,6 +127,16 @@ pub fn nix_copy_to_machine(target: &str, ssh: &IpAddr) -> Result<()> {
             .arg(format!("ssh://root@{}", ssh))
             .arg(target),
     )?;
+    // vulnix operates on store derivations
+    check_cmd(
+        Command::new("nix")
+            .arg("copy")
+            .arg("--derivation")
+            .arg("--substitute-on-destination")
+            .arg("--to")
+            .arg(format!("ssh://root@{}", ssh))
+            .arg(target),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
This is necessary for vulnix as it operates on the `.drv` files. They cannot be generated by nix on the target machine as only build outputs are copied over and no nix expressions are available.

I considered running the vulnix scan as part of the bitte build to avoid this PR. This introduces infinite recursion if we want to include vulnix itself in the scan. I considered it not worth the effort to try since vulnix itself could be a vulnerability that we would not want to ignore by essentially scanning another configuration than the one we actually deploy.

If we would like to try other options in the future to avoid the need for copying store derivations to the target we can always roll back this change.