### PR TITLE
Prevent build closure from being copied

### DIFF
--- a/lib/src/rebuild.rs
+++ b/lib/src/rebuild.rs
@@ -127,16 +127,6 @@ pub fn nix_copy_to_machine(target: &str, ssh: &IpAddr) -> Result<()> {
             .arg(format!("ssh://root@{}", ssh))
             .arg(target),
     )?;
-    // vulnix operates on store derivations
-    check_cmd(
-        Command::new("nix")
-            .arg("copy")
-            .arg("--derivation")
-            .arg("--substitute-on-destination")
-            .arg("--to")
-            .arg(format!("ssh://root@{}", ssh))
-            .arg(target),
-    )?;
     Ok(())
 }
 


### PR DESCRIPTION
Very expensive to push new versions of clients as the entire `.drv` closure needs to be sent to the remote host.

Perhaps we just remotely execute `nix eval .#nixosConfigurations....top-level.drvPath` to create drv tree.